### PR TITLE
chore: update @iobroker/eslint-config to 2.1.0 and fix vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@alcalzone/release-script-plugin-license": "^3.7.0",
         "@alcalzone/release-script-plugin-manual-review": "^3.7.0",
         "@iobroker/adapter-dev": "^1.4.0",
-        "@iobroker/eslint-config": "^2.0.3",
+        "@iobroker/eslint-config": "^2.1.0",
         "@iobroker/testing": "^5.1.1",
         "@tsconfig/node14": "^14.1.5",
         "@tsconfig/node18": "^18.2.4",
@@ -2483,9 +2483,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@alcalzone/release-script-plugin-license": "^3.7.0",
     "@alcalzone/release-script-plugin-manual-review": "^3.7.0",
     "@iobroker/adapter-dev": "^1.4.0",
-  "@iobroker/eslint-config": "^2.0.3",
+  "@iobroker/eslint-config": "^2.1.0",
     "@iobroker/testing": "^5.1.1",
     "@tsconfig/node14": "^14.1.5",
     "@tsconfig/node18": "^18.2.4",


### PR DESCRIPTION
Update @iobroker/eslint-config to 2.1.0 as recommended and run npm audit fix to resolve vulnerabilities.