### PR TITLE
chore: add .commitinfo to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,10 @@ nbproject
 # Build output
 build/*
 !build/main.js
+
 # npm package files
 iobroker.*.tgz
+.commitinfo
 
 Thumbs.db
 


### PR DESCRIPTION
Add .commitinfo to .gitignore to exclude it from version control as recommended by S906.