### PR TITLE
chore: fix schema URLs in VSCode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,11 +11,11 @@
 	"json.schemas": [
 		{
 			"fileMatch": ["io-package.json"],
-			"url": "https://json.schemastore.org/io-package"
+			"url": "https://raw.githubusercontent.com/ioBroker/ioBroker.js-controller/master/schemas/io-package.json"
 		},
 		{
 			"fileMatch": ["admin/jsonConfig.json", "admin/jsonCustom.json", "admin/jsonTab.json"],
-			"url": "https://raw.githubusercontent.com/ioBroker/adapter-react-v5/main/schemas/jsonConfig.json"
+			"url": "https://raw.githubusercontent.com/ioBroker/ioBroker.admin/master/packages/jsonConfig/schemas/jsonConfig.json"
 		}
 	]
 }


### PR DESCRIPTION
Update .vscode/settings.json to use the recommended schema URLs for io-package.json and jsonConfig files (fixes E441, E443).